### PR TITLE
Prevent double quotes escaping when SSR

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,9 +14,7 @@ export default class AppDocument extends Document {
     const renderedPage = renderPage(decoratePage);
 
     const styles = (
-      <style type="text/css" data-meta="jss-ssr">
-        {sheets.toString()}
-      </style>
+      <style type="text/css" data-meta="jss-ssr" dangerouslySetInnerHTML={{ __html: sheets.toString() }} />
     );
 
     return { ...renderedPage, styles };


### PR DESCRIPTION
It happened to me that when I tried to create any styles with quotes in it, SSR escaped it all to html entities, like that: 
```javascript
const clearfix = () => ({
  el: {
    '&::before, &::after': {
      content: '""',
      display: 'table',
    },
  }
})
```
The whole thing was rendered on server as:
```css
...:before {
  content: &quot;&quot;
}
```
Causing the styles to blink (when correct content value was generated on runtime in browser).

So, adding SSR styles as dangerouslySetInnerHTML solved this issue for me. 