### PR TITLE
react-ssr SSR breaks when using react-ssr inside the App component

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "next/babel",
+  ],
+  "plugins": [
+    ["@babel/plugin-proposal-decorators", {
+      "legacy": true
+    }]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "react-jss": "^7.1.0",
-    "next": "^3.2.1",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react-jss": "^8.6.1",
+    "next": "^6.1.1",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-decorators": "7.0.0-beta.42"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,41 @@
+import {Component} from 'react'
+import App, {Container} from 'next/app'
+import withStyle from 'react-jss'
+
+@withStyle({
+  layout: {
+    background: 'pink',
+  }
+})
+class Layout extends Component {
+  render() {
+    return (
+      <div className={this.props.classes.layout}>
+        <header> header </header>
+
+        <main>
+          {this.props.children}
+        </main>
+
+        <footer> footer </footer>
+      </div>
+    )
+  }
+}
+
+export default
+class MyApp extends App {
+
+  render () {
+    const {Component: Page, pageProps} = this.props
+
+    return (
+      <Container>
+        <Layout>
+          <Page {...pageProps} />
+        </Layout>
+      </Container>
+    )
+  }
+
+}


### PR DESCRIPTION
This shows how the SSR breaks when using react-jss inside the App component, which is rendered _**before**_ the decorated page where we're are putting `JssProvider`.

To experience the error, start `npm run dev`, then load the app.

It will seem to work the first time (note the error in the console).

Then refresh the page, and the pink background styles will break (and you'll continue seeing the class name mismatch errors in the console).